### PR TITLE
Fix code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/js/sell.js
+++ b/js/sell.js
@@ -21,9 +21,9 @@ if(localStorage.getItem("username")===null){
         let comissionToShow = Math.round((comissionPercentage * 100)) + PERCENTAGE_SYMBOL;
         let totalCostToShow = MONEY_SYMBOL + ((Math.round(productCost * comissionPercentage * 100) / 100) + parseInt(productCost));
     
-        unitProductCostHTML.innerHTML = unitCostToShow;
-        comissionCostHTML.innerHTML = comissionToShow;
-        totalCostHTML.innerHTML = totalCostToShow;
+        unitProductCostHTML.textContent = unitCostToShow;
+        comissionCostHTML.textContent = comissionToShow;
+        totalCostHTML.textContent = totalCostToShow;
     }
     
     //Función que se ejecuta una vez que se haya lanzado el evento de


### PR DESCRIPTION
Fixes [https://github.com/nahuper/marketplace/security/code-scanning/9](https://github.com/nahuper/marketplace/security/code-scanning/9)

To fix the problem, we need to ensure that any user input is properly sanitized or escaped before being inserted into the DOM. This can be achieved by using `textContent` instead of `innerHTML` for inserting plain text, which prevents the browser from interpreting the text as HTML.

- Replace `innerHTML` with `textContent` for the variables `unitProductCostHTML`, `comissionCostHTML`, and `totalCostHTML`.
- This change should be made in the `updateTotalCosts` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
