### PR TITLE
Fix code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/js/cart.js
+++ b/js/cart.js
@@ -258,7 +258,7 @@ if(localStorage.getItem("username")===null){
         bankTransfer.checked ? true : false
         
         let bankTransferValue = bankTransfer.value;
-        document.getElementById("tipoDePago").innerHTML = `${bankTransferValue}`;
+        document.getElementById("tipoDePago").textContent = bankTransferValue;
         accountNmberBank.disabled = false;
         numberCard.disabled=true;
         securityCode.disabled=true;


### PR DESCRIPTION
Fixes [https://github.com/nahuper/marketplace/security/code-scanning/8](https://github.com/nahuper/marketplace/security/code-scanning/8)

To fix the problem, we need to ensure that any text inserted into the DOM is properly escaped to prevent XSS attacks. Instead of using `innerHTML`, which can interpret the text as HTML, we should use `textContent` to safely insert the text as plain text.

- Replace the usage of `innerHTML` with `textContent` for the `tipoDePago` element.
- This change should be made on line 261 where the `bankTransferValue` is being inserted into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
