### PR TITLE
Fix code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/js/cart.js
+++ b/js/cart.js
@@ -246,7 +246,7 @@ if(localStorage.getItem("username")===null){
         creditCard.checked ? true : false
 
         let creditCardValue = creditCard.value;
-        document.getElementById("tipoDePago").innerHTML=`${creditCardValue}`;
+        document.getElementById("tipoDePago").textContent = creditCardValue;
         accountNmberBank.disabled = true;
         numberCard.disabled=false;
         securityCode.disabled=false;


### PR DESCRIPTION
Fixes [https://github.com/nahuper/marketplace/security/code-scanning/7](https://github.com/nahuper/marketplace/security/code-scanning/7)

To fix the problem, we should avoid using `innerHTML` to insert untrusted data into the DOM. Instead, we can use `textContent`, which will treat the data as plain text and not as HTML, thus preventing any potential XSS attacks.

- Replace the use of `innerHTML` with `textContent` for inserting the `creditCardValue`.
- Ensure that the value is treated as plain text and not as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
